### PR TITLE
Refactor Import section layout and unify info messages

### DIFF
--- a/Dev/changelog.md
+++ b/Dev/changelog.md
@@ -11,6 +11,28 @@ Rejestr zmian w projekcie DataAnalysis.
 
 ---
 
+### [2026-02-01 15:30] - Refactor
+- Poprawki layoutu sekcji Import (Column Mapping):
+  - Data preview: expander na górze z ograniczoną szerokością (max 600px)
+  - Progress bar: ograniczona szerokość (max 400px)
+  - Column mapping: nowy dwukolumnowy layout (60% mapping / 40% summary)
+  - Mapping summary: zawsze widoczne w prawej kolumnie (bez expandera)
+  - Unmapped columns: zawsze widoczne pod Mapping summary (bez expandera)
+  - Status kolumn (Done/Missing): węższe kolumny statusu [1:3] zamiast [1:4]
+  - Weight unit dropdown: ograniczona szerokość (2/5 kontenera)
+  - Przyciski: Back po lewej, Import wyrównany do prawej
+- Pliki: src/ui/views/import_view.py, src/ui/theme.py
+- Branch: refactor/desktop-layout-constraints
+
+### [2026-02-01 14:30] - Refactor
+- Dodanie ograniczeń szerokości layoutu aplikacji (Desktop Layout Constraints)
+  - Główny kontener: max-width 1400px, wycentrowany
+  - Komponenty formularzy: file uploader (600px), selectbox (400px), number input (200px), text input (400px)
+  - Przyciski: naturalna szerokość z min-width 120px
+  - Wykresy i tabele: 100% szerokości kontenera
+  - Responsywność: pełna szerokość poniżej 1500px, komponenty 100% poniżej 768px
+- Branch: refactor/desktop-layout-constraints
+
 ### [2026-02-01 12:00] - Minor
 - Utworzenie pliku changelog.md do rejestrowania zmian w projekcie
 - Dodanie zasady #9 do CLAUDE.md (Session Type First - ustalanie typu sesji na początku pracy)

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -249,7 +249,7 @@ def _render_capacity_validation() -> None:
     st.header("✅ Validation")
 
     if st.session_state.masterdata_df is None:
-        render_message_box("Please import Masterdata first in the Import tab.", "info")
+        st.info("Import Masterdata in the Import tab first")
         return
 
     # Capacity Settings section
@@ -380,7 +380,7 @@ def _render_performance_validation() -> None:
     st.header("✅ Validation")
 
     if st.session_state.orders_df is None:
-        render_message_box("Please import Orders first in the Import tab.", "info")
+        st.info("Import Orders in the Import tab first")
         return
 
     # Performance Settings section

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -746,6 +746,101 @@ def get_custom_css() -> str:
         box-shadow: none !important;
         outline: none !important;
     }}
+
+    /* ===== Desktop Layout Constraint ===== */
+
+    /* 1. Główny kontener - ograniczenie i centrowanie */
+    [data-testid="block-container"],
+    .block-container {{
+        max-width: 1400px !important;
+        padding-left: 2rem !important;
+        padding-right: 2rem !important;
+        margin: 0 auto !important;
+    }}
+
+    /* 2. Komponenty formularzy - max szerokość */
+    [data-testid="stFileUploader"] {{
+        max-width: 600px !important;
+    }}
+
+    .stSelectbox {{
+        max-width: 400px !important;
+    }}
+
+    .stNumberInput {{
+        max-width: 200px !important;
+    }}
+
+    .stTextInput {{
+        max-width: 400px !important;
+    }}
+
+    /* 3. Przyciski - naturalna szerokość (bez stretch) */
+    .stButton > button {{
+        width: auto !important;
+        min-width: 120px !important;
+    }}
+
+    /* 4. Wykresy i tabele - pełna szerokość w obrębie kontenera */
+    [data-testid="stDataFrame"],
+    [data-testid="stPlotlyChart"],
+    .stDataFrame {{
+        width: 100% !important;
+    }}
+
+    /* 5. Responsywność - na mniejszych ekranach pełna szerokość */
+    @media (max-width: 1500px) {{
+        [data-testid="block-container"],
+        .block-container {{
+            max-width: 100% !important;
+            padding-left: 1.5rem !important;
+            padding-right: 1.5rem !important;
+        }}
+    }}
+
+    @media (max-width: 768px) {{
+        [data-testid="stFileUploader"],
+        .stSelectbox,
+        .stNumberInput,
+        .stTextInput {{
+            max-width: 100% !important;
+        }}
+    }}
+
+    /* ===== Import Section Layout ===== */
+
+    /* Data preview container - constrained width */
+    .data-preview-container {{
+        max-width: 600px !important;
+    }}
+
+    .data-preview-container .streamlit-expanderHeader {{
+        max-width: 100% !important;
+    }}
+
+    /* Progress bar in mapping section - shorter */
+    .mapping-progress {{
+        max-width: 400px !important;
+    }}
+
+    .mapping-progress .stProgress {{
+        max-width: 100% !important;
+    }}
+
+    /* Mapping summary panel - right column styling */
+    .mapping-summary-panel {{
+        background-color: {COLORS["surface_elevated"]};
+        border-radius: 8px;
+        padding: 0.75rem 1rem;
+        border: 1px solid {COLORS["border"]};
+        margin-bottom: 0.5rem;
+    }}
+
+    /* Compact field status badges */
+    .mapping-progress + div .stColumns > div:first-child {{
+        max-width: 90px !important;
+        min-width: 70px !important;
+    }}
     </style>
     """
 

--- a/src/ui/views/validation_view.py
+++ b/src/ui/views/validation_view.py
@@ -17,7 +17,7 @@ def render_validation_view(show_header: bool = True) -> None:
         st.header("✅ Validation")
 
     if st.session_state.masterdata_df is None:
-        st.info("First import Masterdata in the Import tab")
+        st.info("Import Masterdata in the Import tab first")
         return
 
     if st.button("Run validation", key="run_validation", type="primary"):


### PR DESCRIPTION
- **Import view**: Two-column layout (50/50) for column mapping
    - Left column: progress bar + status dropdowns (narrower ratio)
    - Right column: Mapping summary + Unmapped columns (always visible, no expanders)
  - **Data preview**: Constrained width (max 600px)
  - **Progress bar**: Constrained width (max 400px)
  - **Import button**: Aligned to right edge of right column
  - **Info messages**: Unified style across Validation and Performance sections to match Capacity  
  Analysis (`st.info` instead of `render_message_box`)

  ## Test plan

  - [x] Navigate to Import tab, upload a file, verify two-column layout
  - [x] Check Mapping summary and Unmapped columns are visible without clicking
  - [x] Verify Import button is aligned to right edge
  - [x] Check Validation tab shows unified info message style
  - [x] Check Performance tab shows unified info message style

  🤖 Generated with [Claude Code](https://claude.ai/code)