### PR TITLE
Fix: Handle pl.Date timestamp columns by casting to Datetime

### DIFF
--- a/src/analytics/performance.py
+++ b/src/analytics/performance.py
@@ -132,6 +132,10 @@ class PerformanceAnalyzer:
                 df = df.with_columns([
                     pl.from_epoch(pl.col("timestamp"), time_unit="s").alias("timestamp")
                 ])
+            elif ts_dtype == pl.Date:
+                df = df.with_columns([
+                    pl.col("timestamp").cast(pl.Datetime).alias("timestamp")
+                ])
             else:
                 raise ValueError(f"Cannot convert timestamp column of type {ts_dtype} to datetime")
 

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -230,6 +230,10 @@ class OrdersIngestPipeline:
                     df = df.with_columns([
                         pl.from_epoch(pl.col("timestamp"), time_unit="s").alias("timestamp")
                     ])
+                elif ts_dtype == pl.Date:
+                    df = df.with_columns([
+                        pl.col("timestamp").cast(pl.Datetime).alias("timestamp")
+                    ])
 
         return IngestResult(
             df=df,

--- a/src/model/orders.py
+++ b/src/model/orders.py
@@ -44,6 +44,10 @@ class OrdersProcessor:
                 result = result.with_columns([
                     pl.col("timestamp").str.to_datetime(strict=False).alias("timestamp")
                 ])
+            elif result["timestamp"].dtype == pl.Date:
+                result = result.with_columns([
+                    pl.col("timestamp").cast(pl.Datetime).alias("timestamp")
+                ])
 
         # Ensure quantity is int
         if "quantity" in result.columns:


### PR DESCRIPTION
## Summary
- Fixes crash when CSV data contains date-only values (e.g. `2024-01-15`) that Polars auto-detects as `pl.Date`
- Added `pl.Date` → `pl.Datetime` cast in all 3 timestamp-handling locations: pipeline ingestion, order normalization, and performance analysis
- Date-only values get midnight time (`00:00:00`) appended automatically

Fixes #17

## Test plan
- [ ] Load a CSV with a date-only timestamp column (no time component)
- [ ] Run performance analysis — should complete without error
- [ ] Verify timestamps have `00:00:00` time appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)