### PR TITLE
Unify European numeric format handling across ingest pipeline

### DIFF
--- a/Dev/changelog.md
+++ b/Dev/changelog.md
@@ -11,6 +11,15 @@ Rejestr zmian w projekcie DataAnalysis.
 
 ---
 
+### [2026-02-16] - Refactor
+- **Ujednolicenie obsługi formatów numerycznych w pipeline**:
+  - Nowy moduł `src/ingest/cleaning.py` z uniwersalną funkcją `clean_numeric_column()`
+  - Obsługuje: europejski przecinek dziesiętny (`1,5`), notację naukową (`1,0E+0`), kropki jako separatory tysięcy (`1.234,56`)
+  - Zastosowano w `pipeline.py` (kolumna `stock`) zamiast inline kodu
+  - Zastosowano w `units.py` (wymiary `length/width/height` i `weight`) — wcześniej wartości jak `"1,5"` cicho stawały się `null`
+  - 9 nowych testów w `test_ingest.py` pokrywających edge cases
+- Branch: `feature/numeric-cleaning`
+
 ### [2026-02-12 20:00] - Feature
 - **Eksport interaktywnych wykresów jako standalone HTML**:
   - Dodano przycisk "Download interactive HTML" pod każdym wykresem w zakładkach Analysis

--- a/src/ingest/cleaning.py
+++ b/src/ingest/cleaning.py
@@ -1,0 +1,29 @@
+"""Uniwersalne funkcje czyszczenia danych numerycznych."""
+
+import polars as pl
+
+
+def clean_numeric_column(col: pl.Expr) -> pl.Expr:
+    """Czyści kolumnę numeryczną z europejskich formatów.
+
+    Obsługuje: przecinek jako separator dziesiętny, notację naukową (1,0E+0),
+    kropki jako separatory tysięcy (1.234,56).
+
+    Strategia: jeśli wartość zawiera przecinek, to kropki traktowane są jako
+    separatory tysięcy (usuwane), a przecinek jako separator dziesiętny (→ kropka).
+    """
+    cleaned = col.cast(pl.Utf8).str.strip_chars()
+
+    has_comma = cleaned.str.contains(",")
+
+    # Ścieżka europejska: usuwamy kropki (tysiące), zamieniamy przecinek na kropkę
+    european = (
+        cleaned
+        .str.replace_all(r"\.", "")  # usuń kropki-tysiące
+        .str.replace_all(",", ".")   # przecinek → kropka
+    )
+
+    # Wybieramy ścieżkę w zależności od obecności przecinka
+    result = pl.when(has_comma).then(european).otherwise(cleaned)
+
+    return result.cast(pl.Float64, strict=False)


### PR DESCRIPTION
Extract clean_numeric_column() into src/ingest/cleaning.py and apply it consistently to stock, dimensions, and weight columns — fixing silent null conversion for values like "1,5" or "1,0E+0" in units.py.