### PR TITLE
Fix Dashboard query performance: partial select + DB indexes

### DIFF
--- a/api/models/analysis_run.py
+++ b/api/models/analysis_run.py
@@ -22,11 +22,11 @@ class AnalysisRun(Base):
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     owner_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     client_name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     status: Mapped[str] = mapped_column(
-        String(50), nullable=False, default="created"
+        String(50), nullable=False, default="created", index=True
     )  # created | ingested | quality_done | capacity_done | performance_done
 
     # File paths on persistent disk
@@ -45,7 +45,7 @@ class AnalysisRun(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_public: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/api/routers/runs.py
+++ b/api/routers/runs.py
@@ -78,6 +78,18 @@ async def create_run(
     return _run_to_response(run)
 
 
+_LIST_COLS = (
+    AnalysisRun.id,
+    AnalysisRun.owner_id,
+    AnalysisRun.client_name,
+    AnalysisRun.status,
+    AnalysisRun.is_public,
+    AnalysisRun.notes,
+    AnalysisRun.created_at,
+    AnalysisRun.updated_at,
+)
+
+
 @router.get("", response_model=RunListResponse)
 async def list_runs(
     my_only: bool = True,
@@ -93,12 +105,12 @@ async def list_runs(
         RunShare.shared_with_user_id == current_user.id
     )
     if my_only:
-        query = select(AnalysisRun).where(
+        query = select(*_LIST_COLS).where(
             (AnalysisRun.owner_id == current_user.id)
             | (AnalysisRun.id.in_(shared_run_ids_q))
         )
     else:
-        query = select(AnalysisRun).where(
+        query = select(*_LIST_COLS).where(
             (AnalysisRun.owner_id == current_user.id)
             | (AnalysisRun.is_public.is_(True))
             | (AnalysisRun.id.in_(shared_run_ids_q))
@@ -121,7 +133,7 @@ async def list_runs(
     total = (await db.execute(count_q)).scalar_one()
 
     query = query.offset((page - 1) * page_size).limit(page_size)
-    runs = (await db.execute(query)).scalars().all()
+    runs = (await db.execute(query)).all()
 
     return RunListResponse(
         items=[

--- a/api/seed.py
+++ b/api/seed.py
@@ -22,6 +22,20 @@ async def init_db() -> None:
     print("Database tables created.")
 
 
+async def migrate_indexes() -> None:
+    """Add indexes to existing DB. Safe to run multiple times."""
+    from sqlalchemy import text
+    stmts = [
+        "CREATE INDEX IF NOT EXISTS ix_analysis_runs_owner_id ON analysis_runs (owner_id)",
+        "CREATE INDEX IF NOT EXISTS ix_analysis_runs_status ON analysis_runs (status)",
+        "CREATE INDEX IF NOT EXISTS ix_analysis_runs_created_at ON analysis_runs (created_at)",
+    ]
+    async with engine.begin() as conn:
+        for stmt in stmts:
+            await conn.execute(text(stmt))
+    print("Indexes applied.")
+
+
 async def create_user(email: str, password: str, name: str) -> None:
     async with SessionLocal() as db:
         existing = await db.execute(select(User).where(User.email == email))
@@ -70,6 +84,7 @@ async def seed_carriers() -> None:
 
 async def main() -> None:
     await init_db()
+    await migrate_indexes()
     await seed_carriers()
 
     # Create a default admin user if env vars are set or args provided


### PR DESCRIPTION
## Problem

Dashboard Vue 3 przy otwarciu wywołuje `GET /api/v1/runs`. Endpoint robił `select(AnalysisRun)` — ładował **wszystkie kolumny** łącznie z `capacity_result`, `performance_result`, `quality_result` (potencjalnie setki MB JSON), po czym używał tylko 7 małych pól metadanych.

Dodatkowo brak indeksów na `owner_id`, `status`, `created_at` powodował pełny skan tabeli `analysis_runs` przy każdym załadowaniu Dashboardu.

## Zmiany

### `api/routers/runs.py`
- `select(AnalysisRun)` → `select(*_LIST_COLS)` — tylko 8 kolumn metadanych
- `.scalars().all()` → `.all()` (Row namedtuple, ta sama składnia dostępu)

### `api/models/analysis_run.py`
- `index=True` na `owner_id`, `status`, `created_at`

### `api/seed.py`
- Nowa funkcja `migrate_indexes()` — `CREATE INDEX IF NOT EXISTS` dla istniejących baz
- Wywoływana automatycznie przy `python -m api.seed`

## Test plan

- [x] 231 testów przechodzi (`pytest tests/ -v`)
- [x] Indeksy zaaplikowane na istniejącej bazie (`python -m api.seed`)
- [x] 2 pre-existing failures w `test_api.py` — niezwiązane z tym PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)