### PR TITLE
Add toast notifications for Notes, Delete, Share, Duplicate, Change password

### DIFF
--- a/frontend/src/components/analysis/NotesModal.vue
+++ b/frontend/src/components/analysis/NotesModal.vue
@@ -28,11 +28,13 @@
 <script setup lang="ts">
 import { ref, onUnmounted } from 'vue'
 import { useRunStore } from '@/stores/run'
+import { useNotificationsStore } from '@/stores/notifications'
 
 const props = defineProps<{ runId: string; initialNotes: string }>()
 const emit = defineEmits<{ close: []; saved: [value: string] }>()
 
 const runStore = useRunStore()
+const notify = useNotificationsStore()
 const localNotes = ref(props.initialNotes)
 const notesSaved = ref(false)
 let notesTimer: ReturnType<typeof setTimeout> | null = null
@@ -44,6 +46,7 @@ function scheduleNotesSave() {
     await runStore.patchRun(props.runId, { notes: localNotes.value })
     emit('saved', localNotes.value)
     notesSaved.value = true
+    notify.push({ type: 'success', title: 'Notes saved' })
     setTimeout(() => { notesSaved.value = false }, 2000)
   }, 500)
 }

--- a/frontend/src/components/analysis/ShareModal.vue
+++ b/frontend/src/components/analysis/ShareModal.vue
@@ -49,10 +49,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { runsApi, type RunShareItem } from '@/api/runs'
+import { useNotificationsStore } from '@/stores/notifications'
 
 const props = defineProps<{ runId: string }>()
 defineEmits<{ close: [] }>()
 
+const notify = useNotificationsStore()
 const shares = ref<RunShareItem[]>([])
 const loading = ref(true)
 const emailInput = ref('')
@@ -74,6 +76,7 @@ async function addShare() {
   try {
     const { data } = await runsApi.addShare(props.runId, emailInput.value)
     shares.value.push(data)
+    notify.push({ type: 'success', title: 'Analysis shared', message: emailInput.value })
     emailInput.value = ''
   } catch (e: any) {
     addError.value = e?.response?.data?.detail ?? 'Failed to share.'
@@ -83,7 +86,9 @@ async function addShare() {
 }
 
 async function revoke(userId: string) {
+  const user = shares.value.find(s => s.user_id === userId)
   await runsApi.removeShare(props.runId, userId)
   shares.value = shares.value.filter(s => s.user_id !== userId)
+  notify.push({ type: 'info', title: 'Share removed', message: user?.email })
 }
 </script>

--- a/frontend/src/views/RunsView.vue
+++ b/frontend/src/views/RunsView.vue
@@ -120,12 +120,14 @@
 import { ref, watch, onMounted } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useRunStore } from '@/stores/run'
+import { useNotificationsStore } from '@/stores/notifications'
 import type { RunListItem } from '@/api/runs'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import NewRunModal from '@/components/analysis/NewRunModal.vue'
 
 const runStore = useRunStore()
 const router = useRouter()
+const notify = useNotificationsStore()
 const showModal = ref(false)
 const confirmDelete = ref<string | null>(null)
 
@@ -150,13 +152,23 @@ function onCreated(id: string) {
 }
 
 async function onDelete(id: string) {
-  await runStore.deleteRun(id)
-  confirmDelete.value = null
+  try {
+    await runStore.deleteRun(id)
+    confirmDelete.value = null
+    notify.push({ type: 'success', title: 'Analysis deleted' })
+  } catch {
+    notify.push({ type: 'error', title: 'Failed to delete analysis' })
+  }
 }
 
 async function onDuplicate(id: string) {
-  const run = await runStore.duplicateRun(id)
-  router.push(`/runs/${run.id}`)
+  try {
+    const run = await runStore.duplicateRun(id)
+    notify.push({ type: 'success', title: 'Analysis duplicated' })
+    router.push(`/runs/${run.id}`)
+  } catch {
+    notify.push({ type: 'error', title: 'Failed to duplicate analysis' })
+  }
 }
 
 async function onTogglePublic(run: RunListItem) {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -52,8 +52,10 @@
 import { reactive, ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { authApi } from '@/api/auth'
+import { useNotificationsStore } from '@/stores/notifications'
 
 const auth = useAuthStore()
+const notify = useNotificationsStore()
 
 const form = reactive({ old_password: '', new_password: '', confirm: '' })
 const loading = ref(false)
@@ -76,6 +78,7 @@ async function submit() {
     form.old_password = ''
     form.new_password = ''
     form.confirm = ''
+    notify.push({ type: 'success', title: 'Password changed' })
   } catch (e: any) {
     error.value = e?.response?.data?.detail ?? 'Failed to change password.'
   } finally {


### PR DESCRIPTION
## Summary

- **Notes** — `NotesModal.vue`: success toast po każdym auto-zapisie notatek (debounce 500ms)
- **Delete analysis** — `RunsView.vue`: success toast po usunięciu; error toast przy błędzie (dodano try/catch)
- **Share** — `ShareModal.vue`: success toast z emailem użytkownika po udostępnieniu; info toast z emailem po cofnięciu dostępu
- **Duplicate** — `RunsView.vue`: success toast po duplikacji; error toast przy błędzie (dodano try/catch)
- **Change password** — `SettingsView.vue`: success toast po zmianie hasła

## Szczegóły

Wszystkie notyfikacje używają istniejącego `useNotificationsStore().push()` i systemu `ToastContainer`. Zmiany dotyczą wyłącznie logiki — bez zmian w UI komponentów toastów.

## Test plan

- [x] TypeScript: zero błędów (`tsc --noEmit`)
- [ ] Notes: wpisać tekst w modalu notatek → toast "Notes saved"
- [ ] Delete: usunąć analizę → toast "Analysis deleted"
- [ ] Share: udostępnić analizę → toast "Analysis shared · email@..."
- [ ] Revoke share: cofnąć dostęp → toast "Share removed · email@..."
- [ ] Duplicate: zduplikować analizę → toast "Analysis duplicated"
- [ ] Change password: zmienić hasło → toast "Password changed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)